### PR TITLE
Implement 'abstract' meta specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,4 @@ Versions of TeXLite in development.
 
 ### v1.0.6
 
-[Put update notes here]
+- Added 'abstract' meta specification, e.g.: `:abstract: Abstract goes here`.

--- a/tests/assets/test_components/abstract.md
+++ b/tests/assets/test_components/abstract.md
@@ -1,0 +1,1 @@
+:abstract: This is my abstract

--- a/tests/assets/test_components/expected/abstract.tex
+++ b/tests/assets/test_components/expected/abstract.tex
@@ -1,0 +1,30 @@
+% meta
+\documentclass[10pt]{extarticle}
+
+% packages
+\usepackage[utf8]{inputenc}
+\usepackage[margin=1.6in]{geometry}
+\usepackage{hyperref}
+\usepackage{amsmath}
+\usepackage{amssymb}
+
+% preamble commands
+\linespread{1.0}
+\usepackage{graphicx}
+\graphicspath{{tests/assets/test_components/}}
+
+% document details
+\date{}
+
+% ------------------------------------------------------------------------------
+\begin{document}
+% ------------------------------------------------------------------------------
+
+\begin{abstract}
+This is my abstract
+\end{abstract}
+
+% ------------------------------------------------------------------------------
+\end{document}
+% ------------------------------------------------------------------------------
+

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -16,6 +16,7 @@ COMPONENTS_TO_TEST = [
     'list',
     'figure',
     'equation',
+    'abstract'
 ]
 
 

--- a/texlite/components/meta.py
+++ b/texlite/components/meta.py
@@ -8,16 +8,18 @@ from texlite import messages as msg
 
 class Meta:
 
-    def __init__(self, title=None, author=None, date=None,
+    def __init__(self, title=None, author=None, date=None, abstract=None,
                  fontsize='10pt', margin='1.6in', pagenumbers=True,
                  linespread=1.0, graphics_path=None):
 
         # specifiable meta options
         # NOTE: validation of options handled in `Meta._validate_options`
+        # by default, defaults are None
         self.options = [
             'title',
             'author',
             'date',
+            'abstract',
             'fontsize', # default: 10pt
             'margin', # default: 1.6in
             'linespread', # default: 1.0
@@ -27,6 +29,7 @@ class Meta:
         self.title = title
         self.author = author
         self.date = date
+        self.abstract = abstract
 
         # document setup options
         self.fontsize = fontsize
@@ -187,5 +190,24 @@ class DocumentEnd:
 
 class MakeTitle:
 
+    def __init__(self, meta):
+        self.title = meta.title
+        self.author = meta.author
+        self.date = meta.date
+        self.abstract = meta.abstract
+
     def tex(self):
-        return r'\maketitle{}'
+
+        lines = []
+
+        if self.title:
+            lines.append(f'{BACKSLASH}maketitle{{}}')
+
+        if self.abstract:
+            lines += [
+                f'{BACKSLASH}begin{{abstract}}',
+                f'{self.abstract}',
+                f'{BACKSLASH}end{{abstract}}'
+            ]
+
+        return '\n'.join(lines)

--- a/texlite/parse.py
+++ b/texlite/parse.py
@@ -146,8 +146,8 @@ def parse(md_lines, graphics_path=None):
     components.insert(0, meta)
 
     # add maketitle if needed
-    if meta.title:
-        components.insert(2, MakeTitle())
+    if meta.title or meta.abstract:
+        components.insert(2, MakeTitle(meta))
 
     # convert tokenised components to lines
     tex_lines = [component.tex() + '\n' for component in components]


### PR DESCRIPTION
 Adds an 'abstract' meta specification, e.g.: `:abstract: Abstract goes here`.