### PR TITLE
Add new layout options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,10 @@
 
 Versions of TeXLite in development.
 
-### v1.1.8 (2020-09-09)
+### v1.2.0 (2020-09-09)
 
 - Made both $$$ and $$ valid for equation enclosure.
 - Made equations ignore empty lines.
 - Added boolean `:nopagenumbers:` option to remove page numbers.
+- Added `:pagesize:` option for page sizes (e.g.: `letter`, `a4paper`).
+- Added boolean `:twocolumn:` option for the document layout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,3 +47,9 @@
 ## [Unreleased]
 
 Versions of TeXLite in development.
+
+### v1.1.8 (2020-09-09)
+
+- Made both $$$ and $$ valid for equation enclosure.
+- Made equations ignore empty lines.
+- Added boolean `:nopagenumbers:` option to remove page numbers.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -156,7 +156,7 @@ Although not as popular in most LaTeX documents, hyperlinks can be specified in 
 
 This will create a link labelled "TeXLite" that goes to the address `https://github.com/lucrae/texlite`.
 
-### Document Setup
+## Document Setup
 
 Specifiying document setup options can actually be done anywhere in the document, but makes the most sense to do at the top. Here is an example of specifying the document details for the heading:
 
@@ -168,16 +168,30 @@ Specifiying document setup options can actually be done anywhere in the document
 
 The lines above would set the document title to "Solution to the Riemann Hypothesis" with the author "Lucien Rae Gentil" and the date "July 11, 2038". Note that because in-line LaTeX commands can be used, you can write `\today{}` to automatically provide the current date.
 
-More specifications are planned to be added, but here is the list so far:
+### With parameters
 
-- `:title:` Sets the document title.
+The following are document setup tags that require a parameter (e.g.: `:fontsize:` requires that you specify a size):
+
+- `:title:`. Sets the document title.
 - `:author:`. Sets the document author.
 - `:date:`. Sets the document date, typically can be used with `\today{}`.
 - `:abstract:`. Adds an 'abstract' section to the start of the document comprising whatever text is specified.
 - `:fontsize:`. Sets the size of the font. Default is `10pt`. Options are: `8pt, 9pt, 10pt, 11pt, 12pt, 14pt, 17pt, 20pt`. Remember to include the `pt`.
 - `:margin:`. Sets the size of the margins. Default is `1.6in`. Unit must be included, and can be any one of `mm, cm, pt, in`.
 - `:linespread:`. Sets the proportional spacing between lines. Default is `1.0`. One-and-a-half spacing is `1.3` and double spacing is `1.6`.
+- `:pagesize:`. Sets the size of the pages (e.g: `letter`, `a4paper`).
 - `:usepackages:`. Includes specified packages to be used in the document. Multiple packages seperated by commas, for example: `:usepackages: hyperref, xcolor`. Note that these packages must be installed in you TeX distribution; if they're not TeXLite will not be able to compile.
+
+### Without parameters
+
+The following are document setup tags with no parameters (e.g.: simply using `:nopagenumbers:` removes page numbers):
+
+- `:nopagenumbers:`. Removes page numbers.
+
+### LaTeX commands
+
+Document setup can also be done simply with LaTeX (e.g.: `\newcommand{}` or `\thispagestyle{empty}` can be used).
+
 
 ## Conclusion
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -179,7 +179,7 @@ The following are document setup tags that require a parameter (e.g.: `:fontsize
 - `:fontsize:`. Sets the size of the font. Default is `10pt`. Options are: `8pt, 9pt, 10pt, 11pt, 12pt, 14pt, 17pt, 20pt`. Remember to include the `pt`.
 - `:margin:`. Sets the size of the margins. Default is `1.6in`. Unit must be included, and can be any one of `mm, cm, pt, in`.
 - `:linespread:`. Sets the proportional spacing between lines. Default is `1.0`. One-and-a-half spacing is `1.3` and double spacing is `1.6`.
-- `:pagesize:`. Sets the size of the pages (e.g: `letter`, `a4paper`).
+- `:pagesize:`. Sets the size of the document pages (e.g: `letter`, `a4paper`).
 - `:usepackages:`. Includes specified packages to be used in the document. Multiple packages seperated by commas, for example: `:usepackages: hyperref, xcolor`. Note that these packages must be installed in you TeX distribution; if they're not TeXLite will not be able to compile.
 
 ### Without parameters
@@ -187,6 +187,7 @@ The following are document setup tags that require a parameter (e.g.: `:fontsize
 The following are document setup tags with no parameters (e.g.: simply using `:nopagenumbers:` removes page numbers):
 
 - `:nopagenumbers:`. Removes page numbers.
+- `:twocolumn:`. Sets the document layout into two columns.
 
 ### LaTeX commands
 

--- a/tests/assets/test_components/expected/meta.tex
+++ b/tests/assets/test_components/expected/meta.tex
@@ -1,5 +1,5 @@
 % meta
-\documentclass[12pt]{extarticle}
+\documentclass[a4paper, 12pt]{extarticle}
 
 % packages
 \usepackage[utf8]{inputenc}
@@ -13,6 +13,7 @@
 \linespread{1.3}
 \usepackage{graphicx}
 \graphicspath{{tests/assets/test_components/}}
+\pagestyle{empty}
 
 % document details
 \title{\textbf{Title Name}}
@@ -24,6 +25,7 @@
 % ------------------------------------------------------------------------------
 
 \maketitle{}
+\thispagestyle{empty}
 
 \color{blue}
 

--- a/tests/assets/test_components/expected/meta.tex
+++ b/tests/assets/test_components/expected/meta.tex
@@ -1,5 +1,5 @@
 % meta
-\documentclass[a4paper, 12pt]{extarticle}
+\documentclass[a4paper, twocolumn, 12pt]{extarticle}
 
 % packages
 \usepackage[utf8]{inputenc}

--- a/tests/assets/test_components/meta.md
+++ b/tests/assets/test_components/meta.md
@@ -4,6 +4,8 @@
 :fontsize: 12pt
 :margin: 2.0in
 :linespread: 1.3
+:pagesize: a4paper
+:nopagenumbers:
 :usepackages: xcolor
 
 \color{blue}

--- a/tests/assets/test_components/meta.md
+++ b/tests/assets/test_components/meta.md
@@ -6,6 +6,7 @@
 :linespread: 1.3
 :pagesize: a4paper
 :nopagenumbers:
+:twocolumn:
 :usepackages: xcolor
 
 \color{blue}

--- a/texlite/components/common.py
+++ b/texlite/components/common.py
@@ -7,6 +7,7 @@ BANNER_LINE = r'% ' + '-' * 78
 SPECIAL_CHARS = r'\#$%^&_{}~'
 NON_ENCAPSULATION_CHARS = SPECIAL_CHARS + r' '
 FONT_SIZES = ['8pt', '9pt', '10pt', '11pt', '12pt', '14pt', '17pt', '20pt']
+EMPTY_LINES = ['', r'\t']
 
 # text regex patterns
 BOLD_RE = r'\*\*([^\*\*]*)\*\*'

--- a/texlite/components/equation.py
+++ b/texlite/components/equation.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import List as L
 
-from texlite.components.common import BACKSLASH
+from texlite.components.common import BACKSLASH, EMPTY_LINES
 
 
 class Equation:
@@ -17,7 +17,7 @@ class Equation:
         # form equation section
         lines = [
             f'{BACKSLASH}begin{{align*}}',
-            *[f'{line} {BACKSLASH*2}' for line in self.equation_lines],
+            *[f'{line} {BACKSLASH*2}' for line in self.equation_lines if line not in EMPTY_LINES],
             f'{BACKSLASH}end{{align*}}'
         ]
 

--- a/texlite/components/meta.py
+++ b/texlite/components/meta.py
@@ -28,6 +28,7 @@ class Meta:
                  usepackages: Optional[str]=None,
                  pagesize: Optional[str]=None,
                  nopagenumbers: bool=False,
+                 twocolumn: bool=False,
                  package_config_path: Optional[Path]=None,
                  graphics_path: Optional[Path]=None):
 
@@ -53,7 +54,8 @@ class Meta:
             'linespread', # default: 1.0
             'usepackages',
             'pagesize',
-            'nopagenumbers',
+            'nopagenumbers', # bool
+            'twocolumn', # bool
         ]
 
         # document detail options
@@ -67,6 +69,7 @@ class Meta:
         self.margin = margin
         self.linespread = linespread
         self.pagesize = pagesize
+        self.twocolumn = twocolumn
 
         # other
         self.usepackages = usepackages
@@ -83,18 +86,11 @@ class Meta:
         # validate options
         self._validate_options()
 
-        lines = [r'% meta']
-
-        if self.pagesize:
-            # add meta preface
-            lines += [
-                f'{BACKSLASH}documentclass[{self.pagesize}, {self.fontsize}]{{extarticle}}',
-            ]
-        else:
-            # add meta preface
-            lines += [
-                f'{BACKSLASH}documentclass[{self.fontsize}]{{extarticle}}',
-            ]
+        # start document with documentclass header
+        lines = [
+            r'% meta',
+            *self._document_header(),
+        ]
 
         # add packages
         lines += [
@@ -160,9 +156,36 @@ class Meta:
             # show warning and enact default
             msg.warning(
                 'Option \'nopagenumbers\' takes no parameters. '
-                'Simply use :nopagenumbers:'
+                'Simply use :nopagenumbers: on its own.'
             )
             self.nopagenumbers = False
+
+        # check nopagestyle
+        if type(self.twocolumn) is not bool:
+
+            # show warning and enact default
+            msg.warning(
+                'Option \'twocolumn\' takes no parameters. '
+                'Simply use :twocolumn: on its own.'
+            )
+            self.twocolumn = False
+
+    def _document_header(self) -> L[str]:
+        '''Returns documentclass header'''
+
+        # get elements for documentclass
+        documentclass_elements = ''
+        if self.pagesize:
+            documentclass_elements += f'{self.pagesize}, '
+        if self.twocolumn:
+            documentclass_elements += f'twocolumn, '
+       
+        documentclass_elements += f'{self.fontsize}'
+
+        return [
+            f'{BACKSLASH}documentclass[{documentclass_elements}]'
+            f'{{extarticle}}',
+        ]
 
     def _packages(self) -> L[str]:
         '''Returns list of TeX import commands for packages'''

--- a/texlite/parse.py
+++ b/texlite/parse.py
@@ -15,6 +15,7 @@ UNORDERED_LIST_PREFIXES = ['-', '+', '*']
 ORDERED_LIST_PREFIXES = [f'{c}.' for c in NUMBERS + LETTERS]
 LIST_PREFIXES = UNORDERED_LIST_PREFIXES + ORDERED_LIST_PREFIXES
 TAB = r' ' * 4 # tabs are four spaces
+EQUATION_ENCLOSURE = ['$$$', '$$']
 
 # set section heading codes
 HEADINGS = {
@@ -54,7 +55,10 @@ def parse(md_lines: L[str], graphics_path: Path=None,
 
             # set meta attribute to specified value
             option_name = prefix[1:-1]
-            setattr(meta, option_name, body)
+            if body:
+                setattr(meta, option_name, body)
+            else:
+                setattr(meta, option_name, True)
 
         # handle heading/section
         elif prefix in HEADINGS.keys():
@@ -87,7 +91,7 @@ def parse(md_lines: L[str], graphics_path: Path=None,
             components.append(Figure(graphics_path, image_path, caption_text))
 
         # handle equation
-        elif prefix == '$$$':
+        elif prefix in EQUATION_ENCLOSURE:
 
             # skip to next line and then iterate through until $$$ is reached
             equation_lines = []
@@ -95,7 +99,7 @@ def parse(md_lines: L[str], graphics_path: Path=None,
             while i < n_lines:
 
                 # break out at end
-                if md_lines[i] == '$$$':
+                if md_lines[i] in EQUATION_ENCLOSURE:
                     break
 
                 equation_lines.append(md_lines[i])


### PR DESCRIPTION
A few useful options and patches for v1.2.0:

- Made both `$$$` and `$$` valid for equation enclosure.
- Made equations ignore empty lines.
- Added boolean `:nopagenumbers:` option to remove page numbers.
- Added `:pagesize:` option for page sizes (e.g.: `letter`, `a4paper`).
- Added boolean `:twocolumn:` option for the document layout.

Resolves #50, #52, and #53.
